### PR TITLE
MAINT: change repository name to glass-examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ html_theme_options = {
         },
         {
             'name': 'GitHub',
-            'url': 'https://github.com/glass-dev/examples',
+            'url': 'https://github.com/glass-dev/glass-examples',
             'icon': 'fab fa-github',
             'type': 'fontawesome',
         },


### PR DESCRIPTION
Update the documentation config to reflect the new repository name (`glass-dev/glass-examples`).

The change was made so that forks have a more sensible identifier by default.