### PR TITLE
DOC: match pip install command to doc version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-#import os
-#import sys
-#sys.path.insert(0, os.path.abspath('..'))
+import os
+# import sys
+# sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------
@@ -79,6 +79,20 @@ html_theme_options = {
 
 html_css_files = [
 ]
+
+# dynamically generate the correct installation instructions for this version
+rtd_version = os.getenv('READTHEDOCS_VERSION', 'stable')
+if rtd_version == 'latest':
+    pip_package = 'git+https://github.com/glass-dev/glass.git'
+elif rtd_version == 'stable':
+    pip_package = 'glass'
+elif rtd_version.startswith('v'):
+    pip_package = f'glass=={rtd_version[1:]}'
+else:
+    pip_package = 'glass'
+rst_epilog = f'''
+.. |pip_package| replace:: {pip_package}
+'''
 
 
 # -- Intersphinx -------------------------------------------------------------

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -13,10 +13,12 @@ and realistic simulations.
 
 __ https://glass.readthedocs.io
 
-To run the examples yourself, you need to have GLASS installed.  The latest
-release is available via pip::
+To run the examples yourself, you need to have GLASS installed.  To install the
+specific version of GLASS for the examples you are reading:
 
-    $ pip install glass
+.. parsed-literal::
+
+    $ pip install |pip_package|
 
 The examples currently require `CAMB`__ to produce angular matter power spectra
 and for the cosmological background.  Make sure you have CAMB installed::


### PR DESCRIPTION
Update the front page of the examples page so that the pip command matches the version being built.