### PR TITLE
API: use RadialWindow

### DIFF
--- a/examples/advanced/plot_s4_galaxies.py
+++ b/examples/advanced/plot_s4_galaxies.py
@@ -65,11 +65,11 @@ cosmo = Cosmology.from_camb(pars)
 # shells of 200 Mpc in comoving distance spacing
 zb = glass.shells.distance_grid(cosmo, 0., 3., dx=200.)
 
-# tophat window function for shells
-zs, ws = glass.shells.tophat_windows(zb)
+# tophat window functions for shells
+ws = glass.shells.tophat_windows(zb)
 
 # compute the angular matter power spectra of the shells with CAMB
-cls = glass.camb.matter_cls(pars, lmax, zs, ws)
+cls = glass.camb.matter_cls(pars, lmax, ws)
 
 # compute Gaussian cls for lognormal fields for 3 correlated shells
 # putting nside here means that the HEALPix pixel window function is applied
@@ -153,15 +153,15 @@ catalogue = np.empty(0, dtype=[('RA', float), ('DEC', float), ('TRUE_Z', float),
 for i, delta_i in enumerate(matter):
 
     # compute the lensing maps for this shell
-    convergence.add_window(delta_i, zs[i], ws[i])
+    convergence.add_window(delta_i, ws[i])
     kappa_i = convergence.kappa
     gamm1_i, gamm2_i = glass.lensing.shear_from_convergence(kappa_i)
 
     # the true galaxy distribution in this shell
-    z_i, dndz_i = glass.shells.restrict(z, dndz, zs[i], ws[i])
+    z_i, dndz_i = glass.shells.restrict(z, dndz, ws[i])
 
     # the photometric galaxy distribution in this shell
-    tomo_z_i, tomo_nz_i = glass.shells.restrict(z, tomo_nz, zs[i], ws[i])
+    tomo_z_i, tomo_nz_i = glass.shells.restrict(z, tomo_nz, ws[i])
 
     # integrate dndz to get the total galaxy density in this shell
     ngal = np.trapz(dndz_i, z_i)

--- a/examples/advanced/plot_shears.py
+++ b/examples/advanced/plot_shears.py
@@ -53,7 +53,7 @@ cosmo = Cosmology.from_camb(pars)
 zb = glass.shells.distance_grid(cosmo, 0., 1., dx=200.)
 
 # tophat window function for shells
-zs, ws = glass.shells.tophat_windows(zb)
+ws = glass.shells.tophat_windows(zb)
 
 # load the angular matter power spectra previously computed with CAMB
 cls = np.load('../basic/cls.npy')
@@ -118,12 +118,12 @@ she = np.zeros(npix, dtype=complex)
 for i, delta_i in enumerate(matter):
 
     # compute the lensing maps for this shell
-    convergence.add_window(delta_i, zs[i], ws[i])
+    convergence.add_window(delta_i, ws[i])
     kappa_i = convergence.kappa
     gamm1_i, gamm2_i = glass.lensing.shear_from_convergence(kappa_i)
 
     # true galaxy redshift distribution in this shell
-    z_i, dndz_i = glass.shells.restrict(z, dndz, zs[i], ws[i])
+    z_i, dndz_i = glass.shells.restrict(z, dndz, ws[i])
 
     # galaxy density in this shell
     ngal = np.trapz(dndz_i, z_i)

--- a/examples/basic/matter.py
+++ b/examples/basic/matter.py
@@ -47,9 +47,6 @@ cosmo = Cosmology.from_camb(pars)
 # shells of 200 Mpc in comoving distance spacing
 zb = glass.shells.distance_grid(cosmo, 0., 1., dx=200.)
 
-# tophat window function for shells
-zs, ws = glass.shells.tophat_windows(zb)
-
 # load precomputed angular matter power spectra
 cls = np.load('cls.npy')
 

--- a/examples/basic/plot_density.py
+++ b/examples/basic/plot_density.py
@@ -49,7 +49,7 @@ cosmo = Cosmology.from_camb(pars)
 zb = glass.shells.distance_grid(cosmo, 0., 1., dx=200.)
 
 # uniform matter weight function
-zs, ws = glass.shells.tophat_windows(zb)
+ws = glass.shells.tophat_windows(zb)
 
 # load the angular matter power spectra previously computed with CAMB
 cls = np.load('cls.npy')
@@ -87,7 +87,7 @@ cube = np.zeros((zcub.size-1,)*3)
 for i, delta_i in enumerate(matter):
 
     # restrict galaxy distribution to this shell
-    z_i, dndz_i = glass.shells.restrict(z, dndz, zs[i], ws[i])
+    z_i, dndz_i = glass.shells.restrict(z, dndz, ws[i])
 
     # compute galaxy density in this shell
     ngal = np.trapz(dndz_i, z_i)
@@ -96,7 +96,7 @@ for i, delta_i in enumerate(matter):
     gal_lon, gal_lat = glass.points.positions_from_delta(ngal, delta_i)
 
     # sample redshifts uniformly in shell
-    gal_z, _ = glass.galaxies.redshifts_from_nz(len(gal_lon), zs[i], ws[i])
+    gal_z, _ = glass.galaxies.redshifts_from_nz(len(gal_lon), ws[i].za, ws[i].wa)
 
     # add counts to cube
     z1 = gal_z*np.cos(np.deg2rad(gal_lon))*np.cos(np.deg2rad(gal_lat))

--- a/examples/basic/plot_lensing.py
+++ b/examples/basic/plot_lensing.py
@@ -57,7 +57,7 @@ cosmo = Cosmology.from_camb(pars)
 zb = glass.shells.distance_grid(cosmo, 0., 1., dx=200.)
 
 # uniform matter weight function
-zs, ws = glass.shells.tophat_windows(zb)
+ws = glass.shells.tophat_windows(zb)
 
 # load the angular matter power spectra previously computed with CAMB
 cls = np.load('cls.npy')
@@ -104,7 +104,7 @@ gamm2_bar = np.zeros(12*nside**2)
 for i, delta_i in enumerate(matter):
 
     # add lensing plane from the window function of this shell
-    convergence.add_window(delta_i, zs[i], ws[i])
+    convergence.add_window(delta_i, ws[i])
 
     # get convergence field
     kappa_i = convergence.kappa
@@ -113,7 +113,7 @@ for i, delta_i in enumerate(matter):
     gamm1_i, gamm2_i = glass.lensing.shear_from_convergence(kappa_i)
 
     # get the restriction of the dndz to this shell
-    z_i, dndz_i = glass.shells.restrict(z, dndz, zs[i], ws[i])
+    z_i, dndz_i = glass.shells.restrict(z, dndz, ws[i])
 
     # compute the galaxy density in this shell
     ngal = np.trapz(dndz_i, z_i)

--- a/examples/basic/shells.py
+++ b/examples/basic/shells.py
@@ -45,10 +45,10 @@ zb = glass.shells.distance_grid(cosmo, 0., 1., dx=200.)
 
 # uniform matter weight function
 # CAMB requires linear ramp for low redshifts
-zs, ws = glass.shells.tophat_windows(zb, wfunc=glass.camb.camb_tophat_wfunc)
+ws = glass.shells.tophat_windows(zb, weight=glass.camb.camb_tophat_weight)
 
 # compute angular matter power spectra with CAMB
-cls = glass.camb.matter_cls(pars, lmax, zs, ws)
+cls = glass.camb.matter_cls(pars, lmax, ws)
 
 
 # %%


### PR DESCRIPTION
Use the `RadialWindow` namedtuple introduced by glass-dev/glass#62 to define window functions for shells.