### PR TITLE
DOC: update intersphinx URL for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ rst_epilog = f'''
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'glass': ('https://glass.readthedocs.io/en/latest/', None),
+    'glass': ('https://glass.readthedocs.io/latest/', None),
 }
 
 


### PR DESCRIPTION
Update the intersphinx URL for the main GLASS documentation.